### PR TITLE
fix godoc link and add ci status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Godoc Reference](https://godoc.org/github.com/secure-io/siv?status.svg)](https://godoc.org/github.com/secure-io/siv)
+[![Godoc Reference](https://godoc.org/github.com/secure-io/siv-go?status.svg)](https://godoc.org/github.com/secure-io/siv-go)
+[![Build Status](https://travis-ci.org/secure-io/siv-go.svg?branch=master)](https://travis-ci.org/secure-io/siv-go)
 
 **Warning - This package is just an experimental proof-of-concept implementation.**
 **This implementation is currently not optimized for performance or (side channel) security.**


### PR DESCRIPTION
This commit fixes the godoc link. Further it
adds a build status icon to the README.md