### PR TITLE
 make AES-SIV-CMAC implemtation compatable with cipher.AEAD 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ before_script:
 
 script:
 - diff -au <(gofmt -d .) <(printf "")
+- diff -au <(go vet -all .) <(printf "")
 - go test -v ./...

--- a/aes_cmac_test.go
+++ b/aes_cmac_test.go
@@ -16,11 +16,11 @@ func TestAESCMAC(t *testing.T) {
 			t.Errorf("Test %d: Failed to create AES_SIV: %v", i, err)
 			continue
 		}
-		ciphertext := c.Seal(nil, v.Plaintext(), v.Nonce(), v.AdditionalData())
+		ciphertext := c.Seal(nil, v.Nonce(), v.Plaintext(), v.AdditionalData())
 		if !bytes.Equal(ciphertext, v.Ciphertext()) {
 			t.Errorf("Test %d: Seal - ciphertext mismatch", i)
 		}
-		plaintext, err := c.Open(ciphertext[c.Overhead():c.Overhead()], ciphertext, v.Nonce(), v.AdditionalData())
+		plaintext, err := c.Open(ciphertext[c.Overhead():c.Overhead()], v.Nonce(), ciphertext, v.AdditionalData())
 		if err != nil {
 			t.Errorf("Test %d: Open - %v", i, err)
 		}
@@ -62,7 +62,7 @@ func benchmarkSeal(key []byte, size int64, b *testing.B) {
 	b.ResetTimer()
 	b.SetBytes(size)
 	for i := 0; i < b.N; i++ {
-		c.Seal(ciphertext[:0], plaintext, nil, nil)
+		c.Seal(ciphertext[:0], nil, plaintext, nil)
 	}
 }
 
@@ -72,12 +72,12 @@ func benchmarkOpen(key []byte, size int64, b *testing.B) {
 		b.Fatal(err)
 	}
 	plaintext := make([]byte, size)
-	ciphertext := c.Seal(nil, plaintext, nil, nil)
+	ciphertext := c.Seal(nil, nil, plaintext, nil)
 
 	b.ResetTimer()
 	b.SetBytes(size)
 	for i := 0; i < b.N; i++ {
-		if _, err := c.Open(plaintext[:0], ciphertext, nil, nil); err != nil {
+		if _, err := c.Open(plaintext[:0], nil, ciphertext, nil); err != nil {
 			panic(err)
 		}
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,86 @@
+package siv_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	siv "github.com/secure-io/siv-go"
+)
+
+func ExampleNewCMAC_encrypt() {
+	// Load your secret key from a safe place and reuse it across multiple
+	// Seal/Open calls. (Obviously don't use this example key for anything
+	// real.) If you want to convert a passphrase to a key, use a suitable
+	// package like argon2 (`go doc golang.org/x/crypto/argon2`).
+	// When decoded the key should be 32 bytes (AES-128) or 64 (AES-256).
+	key, _ := hex.DecodeString("6368616e676520746869732070617373776f726420746f206120736563726574")
+	plaintext := []byte("example_plaintext")
+
+	aessiv, err := siv.NewCMAC(key)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// An empty nonce makes AES-SIV-CMAC a deterministic authenticated encryption
+	// scheme (same plaintext && additional data produces the same ciphertext).
+	// You can also use a random 16 byte nonce to make AES-SIV-CMAC non-deterministic.
+	var nonce []byte = nil
+
+	ciphertext := aessiv.Seal(nil, nonce, plaintext, nil)
+	fmt.Printf("%x\n", ciphertext)
+	// Output: 485bdd0e072f857e623620ebad3eb1925bcb1cafc1780d625710b6bcdd34bf79b2
+}
+
+func ExampleNewCMAC_decrypt() {
+	// Load your secret key from a safe place and reuse it across multiple
+	// Seal/Open calls. (Obviously don't use this example key for anything
+	// real.) If you want to convert a passphrase to a key, use a suitable
+	// package like argon2 (`go doc golang.org/x/crypto/argon2`).
+	// When decoded the key should be 32 bytes (AES-128) or 64 (AES-256).
+	key, _ := hex.DecodeString("6368616e676520746869732070617373776f726420746f206120736563726574")
+	ciphertext, _ := hex.DecodeString("485bdd0e072f857e623620ebad3eb1925bcb1cafc1780d625710b6bcdd34bf79b2")
+	var nonce []byte = nil // An empty nonce was used to encrypt the plaintext.
+
+	aessiv, err := siv.NewCMAC(key)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	plaintext, err := aessiv.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("%s\n", plaintext)
+	// Output: example_plaintext
+}
+func ExampleNewCMAC_encryptdecrypt() {
+	// Load your secret key from a safe place and reuse it across multiple
+	// Seal/Open calls. (Obviously don't use this example key for anything
+	// real.) If you want to convert a passphrase to a key, use a suitable
+	// package like argon2 (`go doc golang.org/x/crypto/argon2`).
+	// When decoded the key should be 32 bytes (AES-128) or 64 (AES-256).
+	key, _ := hex.DecodeString("6368616e676520746869732070617373776f726420746f206120736563726574")
+	plaintext := []byte("example_plaintext")
+
+	aessiv, err := siv.NewCMAC(key)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// We use a random nonce to make AES-SIV-CMAC a probabilistic authenticated
+	// encryption scheme.
+	nonce := make([]byte, aessiv.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		panic(err.Error())
+	}
+
+	ciphertext := aessiv.Seal(nil, nonce, plaintext, nil)
+	plaintext, err = aessiv.Open(plaintext[:0], nonce, ciphertext, nil)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("%s\n", plaintext)
+	// Output: example_plaintext
+}

--- a/siv.go
+++ b/siv.go
@@ -3,11 +3,33 @@
 // found in the LICENSE file.
 
 // Package siv implements the Synthetic Initialization Vector (SIV)
-// authenticated encryption scheme specified in [RFC 5297](https://tools.ietf.org/html/rfc5297)
+// authenticated encryption scheme specified in RFC 5297.
 //
-// It provides an crypto/cipher.AEAD compatable API. However, the
-// nonce may be omitted making AES-SIV a deterministic encryption
-// scheme.
+//
+// AES-SIV-CMAC
+//
+// AES-SIV-CMAC is a misuse-resistant AEAD scheme using AES-{128/192/256}
+// for message privacy and integrity. In contrast to other AEAD schemes - like
+// AES-GCM - AES-SIV-CMAC provides message integrity and message privacy
+// (w.r.t the security of deterministic encryption) even if the nonce is reused
+// or omitted at all.
+// AES-SIV-CMAC creates a ciphertext which is 16 bytes longer than the plaintext.
+// The ciphertext consists of the authentication tag (16 bytes) followed by the
+// encrypted plaintext. For more details see [1].
+//
+//
+// Deterministic AEAD
+//
+// Given the same plaintext and additional data a deterministic AEAD
+// produces always the same ciphertext. Therefore it is not
+// semantically secure. [2]
+// However, any deterministic AEAD implemented by this package accepts
+// a non-nil nonce making the encryption probabilistic. A deterministic
+// AEAD which can be turned into a probabilistic AEAD using a nonce value
+// is called misuse-resistant AEAD.
+//
+// [1] https://tools.ietf.org/html/rfc5297
+// [2] https://en.wikipedia.org/wiki/Deterministic_encryption
 package siv
 
 import (


### PR DESCRIPTION
This PR:
 - Changes the order or the `plaintext` and `nonce` argument for `Seal`/`Open` to be compatable to   
  `cipher.AEAD`
-  Updates the package documentation.
- Adds en/decrption examples for AES-SIV-CMAC. and adds the `go vet` command to the CI.