### PR TITLE
prepare for AMD64 assembler implementations

### DIFF
--- a/aes_cmac.go
+++ b/aes_cmac.go
@@ -7,10 +7,6 @@ package siv
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/subtle"
-	"hash"
-
-	cmac "github.com/aead/cmac/aes"
 )
 
 // NewCMAC returns a cipher.AEAD implementing AES-SIV-CMAC
@@ -20,26 +16,13 @@ import (
 // The returned cipher.AEAD accepts an empty or NonceSize()
 // bytes long nonce.
 func NewCMAC(key []byte) (cipher.AEAD, error) {
-	mac, err := cmac.New(key[:len(key)/2])
-	if err != nil {
-		return nil, err
+	if k := len(key); k != 32 && k != 48 && k != 64 {
+		return nil, aes.KeySizeError(k)
 	}
-	ctrBlock, err := aes.NewCipher(key[len(key)/2:])
-	if err != nil {
-		return nil, err
-	}
-	return &aesSivCMac{
-		cmac: mac,
-		ctr:  &aesCtr{block: ctrBlock},
-	}, nil
+	return &aesSivCMac{newCMAC(key)}, nil
 }
 
-var _ cipher.AEAD = (*aesSivCMac)(nil)
-
-type aesSivCMac struct {
-	cmac hash.Hash
-	ctr  ctrMode
-}
+type aesSivCMac struct{ authEnc }
 
 func (c *aesSivCMac) NonceSize() int { return aes.BlockSize }
 
@@ -49,13 +32,8 @@ func (c *aesSivCMac) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	if n := len(nonce); n != 0 && n != c.NonceSize() {
 		panic("siv: incorrect nonce length given to AES-SIV-CMAC")
 	}
-	v := c.s2v(additionalData, nonce, plaintext)
-	ret, out := sliceForAppend(dst, 16+len(plaintext))
-	copy(out, v[:])
-
-	iv := newIV(v)
-	c.ctr.Reset(iv[:])
-	c.ctr.XORKeyStream(out[16:], plaintext)
+	ret, ciphertext := sliceForAppend(dst, c.Overhead()+len(plaintext))
+	c.authEnc.Seal(ciphertext, nonce, plaintext, additionalData)
 	return ret
 }
 
@@ -63,103 +41,12 @@ func (c *aesSivCMac) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte
 	if n := len(nonce); n != 0 && n != c.NonceSize() {
 		panic("siv: incorrect nonce length given to AES-SIV-CMAC")
 	}
-	var tag [16]byte
-	copy(tag[:], ciphertext[:16])
-	ciphertext = ciphertext[16:]
-
-	iv := newIV(tag)
-	c.ctr.Reset(iv[:])
-
-	ret, out := sliceForAppend(dst, len(ciphertext))
-	c.ctr.XORKeyStream(out, ciphertext)
-	v := c.s2v(additionalData, nonce, out)
-
-	if subtle.ConstantTimeCompare(v[:], tag[:]) != 1 {
-		for i := range out {
-			out[i] = 0
-		}
-		return ret, errOpen
+	if len(ciphertext) < c.Overhead() {
+		return dst, errOpen
+	}
+	ret, plaintext := sliceForAppend(dst, len(ciphertext)-c.Overhead())
+	if err := c.authEnc.Open(plaintext, nonce, ciphertext, additionalData); err != nil {
+		return ret, err
 	}
 	return ret, nil
 }
-
-func (c *aesSivCMac) s2v(additionalData, nonce, plaintext []byte) [16]byte {
-	var b0, b1 [16]byte
-	c.cmac.Write(b0[:])
-	c.cmac.Sum(b1[:0])
-	c.cmac.Reset()
-
-	if len(additionalData) > 0 || len(nonce) > 0 {
-		c.cmac.Write(additionalData)
-		c.cmac.Sum(b0[:0])
-		c.cmac.Reset()
-
-		dbl(&b1)
-		for i := range b1 {
-			b1[i] ^= b0[i]
-		}
-		if len(nonce) > 0 {
-			c.cmac.Write(nonce)
-			c.cmac.Sum(b0[:0])
-			c.cmac.Reset()
-
-			dbl(&b1)
-			for i := range b1 {
-				b1[i] ^= b0[i]
-			}
-		}
-		for i := range b0 {
-			b0[i] = 0
-		}
-	}
-
-	if len(plaintext) >= 16 {
-		n := len(plaintext) - 16
-		copy(b0[:], plaintext[n:])
-		c.cmac.Write(plaintext[:n])
-	} else {
-		copy(b0[:], plaintext)
-		b0[len(plaintext)] = 0x80
-		dbl(&b1)
-	}
-
-	for i := range b0 {
-		b0[i] ^= b1[i]
-	}
-	c.cmac.Write(b0[:])
-	c.cmac.Sum(b0[:0])
-	c.cmac.Reset()
-	return b0
-}
-
-func newIV(v [16]byte) [16]byte {
-	v[8] &= 0x7f
-	v[12] &= 0x7f
-	return v
-}
-
-func dbl(b *[16]byte) {
-	var z byte
-	for i := 15; i >= 0; i-- {
-		zz := b[i] >> 7
-		b[i] = b[i]<<1 | z
-		z = zz
-	}
-	b[15] ^= byte(subtle.ConstantTimeSelect(int(z), 0x87, 0))
-}
-
-var _ (ctrMode) = (*aesCtr)(nil)
-
-type ctrMode interface {
-	cipher.Stream
-
-	Reset(iv []byte)
-}
-
-type aesCtr struct {
-	block cipher.Block
-	ctr   cipher.Stream
-}
-
-func (c *aesCtr) XORKeyStream(dst, src []byte) { c.ctr.XORKeyStream(dst, src) }
-func (c *aesCtr) Reset(iv []byte)              { c.ctr = cipher.NewCTR(c.block, iv) }

--- a/aes_cmac_amd64.go
+++ b/aes_cmac_amd64.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build amd64,!gccgo,!appengine
+
+package siv
+
+import (
+	"golang.org/x/sys/cpu"
+)
+
+func newCMAC(key []byte) authEnc {
+	if cpu.X86.HasAES {
+	}
+	return newCMACGeneric(key)
+}

--- a/aes_cmac_noasm.go
+++ b/aes_cmac_noasm.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package siv
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/subtle"
+	"hash"
+
+	cmac "github.com/aead/cmac/aes"
+)
+
+func newCMACGeneric(key []byte) authEnc {
+	cmac, _ := cmac.New(key[:len(key)/2])
+	block, _ := aes.NewCipher(key[len(key)/2:])
+	return &aesSivCMacGeneric{cmac: cmac, block: block}
+}
+
+type aesSivCMacGeneric struct {
+	cmac  hash.Hash
+	block cipher.Block
+}
+
+func (c *aesSivCMacGeneric) Seal(ciphertext, nonce, plaintext, additionalData []byte) {
+	v := c.s2v(additionalData, nonce, plaintext)
+	copy(ciphertext, v[:])
+
+	iv := newIV(v)
+	ctr := cipher.NewCTR(c.block, iv[:])
+	ctr.XORKeyStream(ciphertext[len(v):], plaintext)
+}
+
+func (c *aesSivCMacGeneric) Open(plaintext, nonce, ciphertext, additionalData []byte) error {
+	var tag [16]byte
+	copy(tag[:], ciphertext[:16])
+	ciphertext = ciphertext[16:]
+
+	iv := newIV(tag)
+	ctr := cipher.NewCTR(c.block, iv[:])
+	ctr.XORKeyStream(plaintext, ciphertext)
+
+	v := c.s2v(additionalData, nonce, plaintext)
+	if subtle.ConstantTimeCompare(v[:], tag[:]) != 1 {
+		for i := range plaintext {
+			plaintext[i] = 0
+		}
+		return errOpen
+	}
+	return nil
+}
+
+func (c *aesSivCMacGeneric) s2v(additionalData, nonce, plaintext []byte) [16]byte {
+	var b0, b1 [16]byte
+	c.cmac.Write(b0[:])
+	c.cmac.Sum(b1[:0])
+	c.cmac.Reset()
+
+	if len(additionalData) > 0 || len(nonce) > 0 {
+		c.cmac.Write(additionalData)
+		c.cmac.Sum(b0[:0])
+		c.cmac.Reset()
+
+		dbl(&b1)
+		for i := range b1 {
+			b1[i] ^= b0[i]
+		}
+		if len(nonce) > 0 {
+			c.cmac.Write(nonce)
+			c.cmac.Sum(b0[:0])
+			c.cmac.Reset()
+
+			dbl(&b1)
+			for i := range b1 {
+				b1[i] ^= b0[i]
+			}
+		}
+		for i := range b0 {
+			b0[i] = 0
+		}
+	}
+
+	if len(plaintext) >= 16 {
+		n := len(plaintext) - 16
+		copy(b0[:], plaintext[n:])
+		c.cmac.Write(plaintext[:n])
+	} else {
+		copy(b0[:], plaintext)
+		b0[len(plaintext)] = 0x80
+		dbl(&b1)
+	}
+
+	for i := range b0 {
+		b0[i] ^= b1[i]
+	}
+	c.cmac.Write(b0[:])
+	c.cmac.Sum(b0[:0])
+	c.cmac.Reset()
+	return b0
+}
+
+func newIV(v [16]byte) [16]byte {
+	v[8] &= 0x7f
+	v[12] &= 0x7f
+	return v
+}
+
+func dbl(b *[16]byte) {
+	var z byte
+	for i := 15; i >= 0; i-- {
+		zz := b[i] >> 7
+		b[i] = b[i]<<1 | z
+		z = zz
+	}
+	b[15] ^= byte(subtle.ConstantTimeSelect(int(z), 0x87, 0))
+}

--- a/aes_cmac_ref.go
+++ b/aes_cmac_ref.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build !amd64 gccgo appengine
+
+package siv
+
+func newCMAC(key []byte) authEnc { return newCMACGeneric(key) }

--- a/aes_gcm.go
+++ b/aes_gcm.go
@@ -7,26 +7,20 @@ package siv
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/subtle"
-	"encoding/binary"
 )
 
 // NewGCM returns a cipher.AEAD implementing the AES-GCM-SIV
 // construction. The key must be either 16 or 32 bytes long.
 func NewGCM(key []byte) (cipher.AEAD, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil || len(key) == 24 { // Disallow 192 bit keys
-		return nil, aes.KeySizeError(len(key))
+	if k := len(key); k != 16 && k != 32 {
+		return nil, aes.KeySizeError(k)
 	}
-	return &aesGcmSiv{block: block, keyLen: len(key)}, nil
+	return &aesGcmSiv{newGCM(key)}, nil
 }
 
 var _ cipher.AEAD = (*aesGcmSiv)(nil)
 
-type aesGcmSiv struct {
-	block  cipher.Block
-	keyLen int
-}
+type aesGcmSiv struct{ authEnc }
 
 func (c *aesGcmSiv) NonceSize() int { return 12 }
 
@@ -42,24 +36,8 @@ func (c *aesGcmSiv) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 	if uint64(len(additionalData)) > 1<<36 {
 		panic("siv: additional data too large for AES-GCM-SIV")
 	}
-
-	ret, ciphertext := sliceForAppend(dst, len(plaintext)+16)
-	encKey, authKey := c.deriveKeys(nonce)
-
-	var tag [16]byte
-	polyvalGeneric(&tag, additionalData, plaintext, authKey)
-	for i := range nonce {
-		tag[i] ^= nonce[i]
-	}
-	tag[15] &= 0x7f
-
-	block, _ := aes.NewCipher(encKey)
-	block.Encrypt(tag[:], tag[:])
-	ctrBlock := tag
-	ctrBlock[15] |= 0x80
-
-	xorKeystreamGeneric(ciphertext, plaintext, encKey, ctrBlock[:])
-	copy(ciphertext[len(plaintext):], tag[:])
+	ret, ciphertext := sliceForAppend(dst, len(plaintext)+c.Overhead())
+	c.authEnc.Seal(ciphertext, nonce, plaintext, additionalData)
 	return ret
 }
 
@@ -76,69 +54,9 @@ func (c *aesGcmSiv) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte,
 	if len(ciphertext) < c.Overhead() {
 		return nil, errOpen
 	}
-
-	tag := ciphertext[len(ciphertext)-c.Overhead():]
-	ciphertext = ciphertext[:len(ciphertext)-c.Overhead()]
-	ret, plaintext := sliceForAppend(dst, len(ciphertext))
-
-	encKey, authKey := c.deriveKeys(nonce)
-	var ctrBlock [16]byte
-	copy(ctrBlock[:], tag)
-	ctrBlock[15] |= 0x80
-	xorKeystreamGeneric(plaintext, ciphertext, encKey, ctrBlock[:])
-
-	var sum [16]byte
-	polyvalGeneric(&sum, additionalData, plaintext, authKey)
-	for i := range nonce {
-		sum[i] ^= nonce[i]
-	}
-	sum[15] &= 0x7f
-
-	block, _ := aes.NewCipher(encKey)
-	block.Encrypt(sum[:], sum[:])
-	if subtle.ConstantTimeCompare(sum[:], tag[:]) != 1 {
-		for i := range plaintext {
-			plaintext[i] = 0
-		}
-		return nil, errOpen
+	ret, plaintext := sliceForAppend(dst, len(ciphertext)-c.Overhead())
+	if err := c.authEnc.Open(plaintext, nonce, ciphertext, additionalData); err != nil {
+		return ret, err
 	}
 	return ret, nil
-}
-
-func (c *aesGcmSiv) deriveKeys(nonce []byte) (encKey, authKey []byte) {
-	var counter [16]byte
-	encKey = make([]byte, 32)
-	authKey = make([]byte, 16)
-	copy(counter[4:], nonce[:])
-
-	var tmp [16]byte
-	binary.LittleEndian.PutUint32(counter[:4], 0)
-	c.block.Encrypt(tmp[:], counter[:])
-	copy(authKey[0:], tmp[:8])
-
-	binary.LittleEndian.PutUint32(counter[:4], 1)
-	c.block.Encrypt(tmp[:], counter[:])
-	copy(authKey[8:], tmp[:8])
-
-	binary.LittleEndian.PutUint32(counter[:4], 2)
-	c.block.Encrypt(tmp[:], counter[:])
-	copy(encKey[0:], tmp[:8])
-
-	binary.LittleEndian.PutUint32(counter[:4], 3)
-	c.block.Encrypt(tmp[:], counter[:])
-	copy(encKey[8:], tmp[:8])
-
-	if c.keyLen == 16 {
-		return encKey[:16], authKey
-	}
-
-	binary.LittleEndian.PutUint32(counter[:4], 4)
-	c.block.Encrypt(tmp[:], counter[:])
-	copy(encKey[16:], tmp[:8])
-
-	binary.LittleEndian.PutUint32(counter[:4], 5)
-	c.block.Encrypt(tmp[:], counter[:])
-	copy(encKey[24:], tmp[:8])
-
-	return encKey, authKey
 }

--- a/aes_gcm_amd64.go
+++ b/aes_gcm_amd64.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build amd64,!gccgo,!appengine
+
+package siv
+
+import (
+	"golang.org/x/sys/cpu"
+)
+
+func newGCM(key []byte) authEnc {
+	if cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ {
+	}
+	return newGCMGeneric(key)
+}

--- a/aes_gcm_ref.go
+++ b/aes_gcm_ref.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build !amd64 gccgo appengine
+
+package siv
+
+func newGCM(key []byte) authEnc { return newGCMGeneric(key) }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/secure-io/siv-go
 
-require github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1
+require (
+	github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1
+	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4aoV2Iu8bR55nU6iKMVfYVLjY=
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
+golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
+golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/siv.go
+++ b/siv.go
@@ -54,6 +54,12 @@ import (
 
 var errOpen = errors.New("siv: message authentication failed")
 
+type authEnc interface {
+	Seal(ciphertext, nonce, plaintext, additionalData []byte)
+
+	Open(plaintext, nonce, ciphertext, additionalData []byte) error
+}
+
 // sliceForAppend takes a slice and a requested number of bytes. It returns a
 // slice with the contents of the given slice followed by that many bytes and a
 // second slice that aliases into it and contains only the extra bytes. If the


### PR DESCRIPTION
This commit prepares the AES-GCM-SIV and AES-SIV-CMAC
implementation for specialized AMD64 assembly.

Therefore this commit moves the entire generic logic
for AES-* to *_noasm.go. It also adds the private
`authEnc` interface implemented by generic/platform-
dependent code.