### PR TITLE
add AES-SIV-CMAC amd64 assembler implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ branches:
 before_script:
 - go mod download
 - diff -au <(go mod verify) <(printf "all modules verified\n")
+- go get -u github.com/klauspost/asmfmt/cmd/asmfmt
 
 script:
 - diff -au <(gofmt -d .) <(printf "")
+- diff -au <(asmfmt -d .) <(printf "")
 - diff -au <(go vet -all .) <(printf "")
 - go test -v ./...

--- a/aes_cmac.go
+++ b/aes_cmac.go
@@ -22,7 +22,7 @@ func NewCMAC(key []byte) (cipher.AEAD, error) {
 	return &aesSivCMac{newCMAC(key)}, nil
 }
 
-type aesSivCMac struct{ authEnc }
+type aesSivCMac struct{ aead }
 
 func (c *aesSivCMac) NonceSize() int { return aes.BlockSize }
 
@@ -33,7 +33,7 @@ func (c *aesSivCMac) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 		panic("siv: incorrect nonce length given to AES-SIV-CMAC")
 	}
 	ret, ciphertext := sliceForAppend(dst, c.Overhead()+len(plaintext))
-	c.authEnc.Seal(ciphertext, nonce, plaintext, additionalData)
+	c.seal(ciphertext, nonce, plaintext, additionalData)
 	return ret
 }
 
@@ -45,7 +45,7 @@ func (c *aesSivCMac) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte
 		return dst, errOpen
 	}
 	ret, plaintext := sliceForAppend(dst, len(ciphertext)-c.Overhead())
-	if err := c.authEnc.Open(plaintext, nonce, ciphertext, additionalData); err != nil {
+	if err := c.open(plaintext, nonce, ciphertext, additionalData); err != nil {
 		return ret, err
 	}
 	return ret, nil

--- a/aes_cmac_amd64.go
+++ b/aes_cmac_amd64.go
@@ -7,11 +7,61 @@
 package siv
 
 import (
+	"crypto/subtle"
+	"hash"
+
+	cmac "github.com/aead/cmac/aes"
 	"golang.org/x/sys/cpu"
 )
 
-func newCMAC(key []byte) authEnc {
+func keySchedule(keys, key *byte, keyLen uint64)
+
+func xorKeyStream(dst, src, iv, keys []byte, keyLen uint64)
+
+func newCMAC(key []byte) aead {
 	if cpu.X86.HasAES {
+		cmac, _ := cmac.New(key[:len(key)/2])
+		key = key[len(key)/2:]
+		keys := make([]byte, 4*(28+len(key)))
+		keySchedule(&keys[0], &key[0], uint64(len(key)))
+		return &aesSivCMacAsm{
+			cmac:      cmac,
+			keys:      keys,
+			keyLength: len(key),
+		}
 	}
 	return newCMACGeneric(key)
+}
+
+type aesSivCMacAsm struct {
+	cmac      hash.Hash
+	keys      []byte
+	keyLength int
+}
+
+func (c *aesSivCMacAsm) seal(ciphertext, nonce, plaintext, additionalData []byte) {
+	v := s2vGeneric(additionalData, nonce, plaintext, c.cmac)
+	copy(ciphertext, v[:])
+	ciphertext = ciphertext[len(v):]
+
+	iv := newIV(v)
+	xorKeyStream(ciphertext, plaintext, iv[:], c.keys, uint64(c.keyLength))
+}
+
+func (c *aesSivCMacAsm) open(plaintext, nonce, ciphertext, additionalData []byte) error {
+	var v [16]byte
+	copy(v[:], ciphertext)
+	ciphertext = ciphertext[len(v):]
+
+	iv := newIV(v)
+	xorKeyStream(plaintext, ciphertext, iv[:], c.keys, uint64(c.keyLength))
+
+	tag := s2vGeneric(additionalData, nonce, plaintext, c.cmac)
+	if subtle.ConstantTimeCompare(v[:], tag[:]) != 1 {
+		for i := range plaintext {
+			plaintext[i] = 0
+		}
+		return errOpen
+	}
+	return nil
 }

--- a/aes_cmac_amd64.s
+++ b/aes_cmac_amd64.s
@@ -1,0 +1,411 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build amd64,!gccgo,!appengine
+
+#include "textflag.h"
+#include "aes_macros_amd64.s"
+
+#define LOAD_COUNTER(C, c0, c1, T) \
+	MOVQ   c0, C; \
+	MOVQ   c1, T; \
+	PSLLDQ $8, T; \
+	PXOR   T, C
+
+#define INC_COUNTER(c0, c1) \
+	BSWAPQ c1;     \
+	BSWAPQ c0;     \
+	ADDQ   $1, c1; \
+	ADCQ   $0, c0; \
+	BSWAPQ c1;     \
+	BSWAPQ c0
+
+// func keySchedule(keys []uint32, key []byte)
+TEXT ·keySchedule(SB), NOSPLIT, $0
+	MOVQ keys+0(FP), AX
+	MOVQ key+8(FP), BX
+	MOVQ keyLen+16(FP), DX
+
+	CMPQ DX, $24
+	JE   aes_192
+	JB   aes_128
+
+aes_256:
+	MOVUPS (0 * 16)(BX), X0
+	MOVUPS (1 * 16)(BX), X1
+	AES_KEY_SCHEDULE_256(AX, X0, X1, X2, X3)
+	JMP    return
+
+aes_192:
+	MOVUPS (0 * 16)(BX), X0
+	MOVQ   (1 * 16)(BX), X1
+	AES_KEY_SCHEDULE_192(AX, X0, X1, X2, X3, X4, X5, X6)
+	JMP    return
+
+aes_128:
+	MOVUPS 0(BX), X0
+	AES_KEY_SCHEDULE_128(AX, X0, X1, X2)
+
+return:
+	RET
+
+// func xorKeyStream(dst, src, iv, keys []byte, keyLen uint64)
+TEXT ·xorKeyStream(SB), 4, $0-104
+	MOVQ dst+0(FP), DI
+	MOVQ src+24(FP), SI
+	MOVQ src_len+32(FP), DX
+	MOVQ iv+48(FP), BX
+	MOVQ keys+72(FP), AX
+	MOVQ keyLen+96(FP), CX
+
+	TESTQ DX, DX
+	JZ    return
+
+	MOVQ 0(BX), R8
+	MOVQ 8(BX), R9
+
+	CMPQ CX, $24
+	JE   aes_192
+	JB   aes_128
+
+aes_256:
+	CALL _xorKeyStream256<>(SB)
+	JMP  return
+
+aes_192:
+	CALL _xorKeyStream192<>(SB)
+	JMP  return
+
+aes_128:
+	CALL _xorKeyStream128<>(SB)
+
+return:
+	RET
+
+TEXT _xorKeyStream128<>(SB), NOSPLIT, $0
+	CMPQ DX, $64
+	JB   loop_1
+	CMPQ DX, $128
+	JB   loop_4
+
+loop_8:
+	LOAD_COUNTER(X0, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X1, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X2, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X3, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X4, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X5, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X6, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X7, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+
+	AES_128_8(X0, X1, X2, X3, X4, X5, X6, X7, X8, AX)
+	PXOR   (0 * 16)(SI), X0
+	PXOR   (1 * 16)(SI), X1
+	PXOR   (2 * 16)(SI), X2
+	PXOR   (3 * 16)(SI), X3
+	PXOR   (4 * 16)(SI), X4
+	PXOR   (5 * 16)(SI), X5
+	PXOR   (6 * 16)(SI), X6
+	PXOR   (7 * 16)(SI), X7
+	MOVUPS X0, (0 * 16)(DI)
+	MOVUPS X1, (1 * 16)(DI)
+	MOVUPS X2, (2 * 16)(DI)
+	MOVUPS X3, (3 * 16)(DI)
+	MOVUPS X4, (4 * 16)(DI)
+	MOVUPS X5, (5 * 16)(DI)
+	MOVUPS X6, (6 * 16)(DI)
+	MOVUPS X7, (7 * 16)(DI)
+	ADDQ   $128, SI
+	ADDQ   $128, DI
+	SUBQ   $128, DX
+	CMPQ   DX, $128
+	JAE    loop_8
+	TESTQ  DX, DX
+	JZ     return
+	CMPQ   DX, $64
+	JB     loop_1
+
+loop_4:
+	LOAD_COUNTER(X0, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X1, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X2, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X3, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+
+	AES_128_4(X0, X1, X2, X3, X4, AX)
+	PXOR   (0 * 16)(SI), X0
+	PXOR   (1 * 16)(SI), X1
+	PXOR   (2 * 16)(SI), X2
+	PXOR   (3 * 16)(SI), X3
+	MOVUPS X0, (0 * 16)(DI)
+	MOVUPS X1, (1 * 16)(DI)
+	MOVUPS X2, (2 * 16)(DI)
+	MOVUPS X3, (3 * 16)(DI)
+	ADDQ   $64, SI
+	ADDQ   $64, DI
+	SUBQ   $64, DX
+	CMPQ   DX, $64
+	JAE    loop_4
+	TESTQ  DX, DX
+	JZ     return
+
+loop_1:
+	LOAD_COUNTER(X0, R8, R9, X1)
+	AES_128(X0, X1, AX)
+	CMPQ   DX, $16
+	JB     finalize
+	PXOR   0(SI), X0
+	MOVUPS X0, 0(DI)
+	INC_COUNTER(R8, R9)
+	ADDQ   $16, SI
+	ADDQ   $16, DI
+	SUBQ   $16, DX
+	JMP    loop_1
+
+finalize:
+	TESTQ DX, DX
+	JZ    return
+
+finalize_loop:
+	MOVQ   X0, R10
+	PSRLDQ $1, X0
+	MOVB   0(SI), R11
+	XORQ   R11, R10
+	MOVB   R10, 0(DI)
+	INCQ   SI
+	INCQ   DI
+	DECQ   DX
+	JNZ    finalize_loop
+
+return:
+	RET
+
+TEXT _xorKeyStream192<>(SB), NOSPLIT, $0
+	CMPQ DX, $64
+	JB   loop_1
+	CMPQ DX, $128
+	JB   loop_4
+
+loop_8:
+	LOAD_COUNTER(X0, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X1, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X2, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X3, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X4, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X5, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X6, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X7, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+
+	AES_192_8(X0, X1, X2, X3, X4, X5, X6, X7, X8, AX)
+	PXOR   (0 * 16)(SI), X0
+	PXOR   (1 * 16)(SI), X1
+	PXOR   (2 * 16)(SI), X2
+	PXOR   (3 * 16)(SI), X3
+	PXOR   (4 * 16)(SI), X4
+	PXOR   (5 * 16)(SI), X5
+	PXOR   (6 * 16)(SI), X6
+	PXOR   (7 * 16)(SI), X7
+	MOVUPS X0, (0 * 16)(DI)
+	MOVUPS X1, (1 * 16)(DI)
+	MOVUPS X2, (2 * 16)(DI)
+	MOVUPS X3, (3 * 16)(DI)
+	MOVUPS X4, (4 * 16)(DI)
+	MOVUPS X5, (5 * 16)(DI)
+	MOVUPS X6, (6 * 16)(DI)
+	MOVUPS X7, (7 * 16)(DI)
+	ADDQ   $128, SI
+	ADDQ   $128, DI
+	SUBQ   $128, DX
+	CMPQ   DX, $128
+	JAE    loop_8
+	TESTQ  DX, DX
+	JZ     return
+	CMPQ   DX, $64
+	JB     loop_1
+
+loop_4:
+	LOAD_COUNTER(X0, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X1, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X2, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X3, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+
+	AES_192_4(X0, X1, X2, X3, X4, AX)
+	PXOR   (0 * 16)(SI), X0
+	PXOR   (1 * 16)(SI), X1
+	PXOR   (2 * 16)(SI), X2
+	PXOR   (3 * 16)(SI), X3
+	MOVUPS X0, (0 * 16)(DI)
+	MOVUPS X1, (1 * 16)(DI)
+	MOVUPS X2, (2 * 16)(DI)
+	MOVUPS X3, (3 * 16)(DI)
+	ADDQ   $64, SI
+	ADDQ   $64, DI
+	SUBQ   $64, DX
+	CMPQ   DX, $64
+	JAE    loop_4
+	TESTQ  DX, DX
+	JZ     return
+
+loop_1:
+	LOAD_COUNTER(X0, R8, R9, X1)
+	AES_192(X0, X1, AX)
+	CMPQ   DX, $16
+	JB     finalize
+	PXOR   0(SI), X0
+	MOVUPS X0, 0(DI)
+	INC_COUNTER(R8, R9)
+	ADDQ   $16, SI
+	ADDQ   $16, DI
+	SUBQ   $16, DX
+	JMP    loop_1
+
+finalize:
+	TESTQ DX, DX
+	JZ    return
+
+finalize_loop:
+	MOVQ   X0, R10
+	PSRLDQ $1, X0
+	MOVB   0(SI), R11
+	XORQ   R11, R10
+	MOVB   R10, 0(DI)
+	INCQ   SI
+	INCQ   DI
+	DECQ   DX
+	JNZ    finalize_loop
+
+return:
+	RET
+
+TEXT _xorKeyStream256<>(SB), NOSPLIT, $0
+	CMPQ DX, $64
+	JB   loop_1
+	CMPQ DX, $128
+	JB   loop_4
+
+loop_8:
+	LOAD_COUNTER(X0, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X1, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X2, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X3, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X4, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X5, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X6, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X7, R8, R9, X8)
+	INC_COUNTER(R8, R9)
+
+	AES_256_8(X0, X1, X2, X3, X4, X5, X6, X7, X8, AX)
+	PXOR   (0 * 16)(SI), X0
+	PXOR   (1 * 16)(SI), X1
+	PXOR   (2 * 16)(SI), X2
+	PXOR   (3 * 16)(SI), X3
+	PXOR   (4 * 16)(SI), X4
+	PXOR   (5 * 16)(SI), X5
+	PXOR   (6 * 16)(SI), X6
+	PXOR   (7 * 16)(SI), X7
+	MOVUPS X0, (0 * 16)(DI)
+	MOVUPS X1, (1 * 16)(DI)
+	MOVUPS X2, (2 * 16)(DI)
+	MOVUPS X3, (3 * 16)(DI)
+	MOVUPS X4, (4 * 16)(DI)
+	MOVUPS X5, (5 * 16)(DI)
+	MOVUPS X6, (6 * 16)(DI)
+	MOVUPS X7, (7 * 16)(DI)
+	ADDQ   $128, SI
+	ADDQ   $128, DI
+	SUBQ   $128, DX
+	CMPQ   DX, $128
+	JAE    loop_8
+	TESTQ  DX, DX
+	JZ     return
+	CMPQ   DX, $64
+	JB     loop_1
+
+loop_4:
+	LOAD_COUNTER(X0, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X1, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X2, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+	LOAD_COUNTER(X3, R8, R9, X4)
+	INC_COUNTER(R8, R9)
+
+	AES_256_4(X0, X1, X2, X3, X4, AX)
+	PXOR   (0 * 16)(SI), X0
+	PXOR   (1 * 16)(SI), X1
+	PXOR   (2 * 16)(SI), X2
+	PXOR   (3 * 16)(SI), X3
+	MOVUPS X0, (0 * 16)(DI)
+	MOVUPS X1, (1 * 16)(DI)
+	MOVUPS X2, (2 * 16)(DI)
+	MOVUPS X3, (3 * 16)(DI)
+	ADDQ   $64, SI
+	ADDQ   $64, DI
+	SUBQ   $64, DX
+	CMPQ   DX, $64
+	JAE    loop_4
+	TESTQ  DX, DX
+	JZ     return
+
+loop_1:
+	LOAD_COUNTER(X0, R8, R9, X1)
+	AES_256(X0, X1, AX)
+	CMPQ   DX, $16
+	JB     finalize
+	PXOR   0(SI), X0
+	MOVUPS X0, 0(DI)
+	INC_COUNTER(R8, R9)
+	ADDQ   $16, SI
+	ADDQ   $16, DI
+	SUBQ   $16, DX
+	JMP    loop_1
+
+finalize:
+	TESTQ DX, DX
+	JZ    return
+
+finalize_loop:
+	MOVQ   X0, R10
+	PSRLDQ $1, X0
+	MOVB   0(SI), R11
+	XORQ   R11, R10
+	MOVB   R10, 0(DI)
+	INCQ   SI
+	INCQ   DI
+	DECQ   DX
+	JNZ    finalize_loop
+
+return:
+	RET

--- a/aes_cmac_noasm.go
+++ b/aes_cmac_noasm.go
@@ -6,4 +6,6 @@
 
 package siv
 
-func newCMAC(key []byte) authEnc { return newCMACGeneric(key) }
+type aesSivCMacImpl = aesSivCMacGeneric
+
+func newCMAC(key []byte) aead { return newCMACGeneric(key) }

--- a/aes_gcm.go
+++ b/aes_gcm.go
@@ -20,7 +20,7 @@ func NewGCM(key []byte) (cipher.AEAD, error) {
 
 var _ cipher.AEAD = (*aesGcmSiv)(nil)
 
-type aesGcmSiv struct{ authEnc }
+type aesGcmSiv struct{ aead }
 
 func (c *aesGcmSiv) NonceSize() int { return 12 }
 
@@ -37,7 +37,7 @@ func (c *aesGcmSiv) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
 		panic("siv: additional data too large for AES-GCM-SIV")
 	}
 	ret, ciphertext := sliceForAppend(dst, len(plaintext)+c.Overhead())
-	c.authEnc.Seal(ciphertext, nonce, plaintext, additionalData)
+	c.seal(ciphertext, nonce, plaintext, additionalData)
 	return ret
 }
 
@@ -55,7 +55,7 @@ func (c *aesGcmSiv) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte,
 		return nil, errOpen
 	}
 	ret, plaintext := sliceForAppend(dst, len(ciphertext)-c.Overhead())
-	if err := c.authEnc.Open(plaintext, nonce, ciphertext, additionalData); err != nil {
+	if err := c.open(plaintext, nonce, ciphertext, additionalData); err != nil {
 		return ret, err
 	}
 	return ret, nil

--- a/aes_gcm_amd64.go
+++ b/aes_gcm_amd64.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-func newGCM(key []byte) authEnc {
+func newGCM(key []byte) aead {
 	if cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ {
 	}
 	return newGCMGeneric(key)

--- a/aes_gcm_generic.go
+++ b/aes_gcm_generic.go
@@ -11,17 +11,19 @@ import (
 	"encoding/binary"
 )
 
-func newGCMGeneric(key []byte) authEnc {
+func newGCMGeneric(key []byte) aead {
 	block, _ := aes.NewCipher(key)
 	return &aesGcmSivGeneric{block: block, keyLen: len(key)}
 }
+
+var _ aead = (*aesGcmSivGeneric)(nil)
 
 type aesGcmSivGeneric struct {
 	block  cipher.Block
 	keyLen int
 }
 
-func (c *aesGcmSivGeneric) Seal(ciphertext, nonce, plaintext, additionalData []byte) {
+func (c *aesGcmSivGeneric) seal(ciphertext, nonce, plaintext, additionalData []byte) {
 	encKey, authKey := c.deriveKeys(nonce)
 
 	var tag [16]byte
@@ -40,7 +42,7 @@ func (c *aesGcmSivGeneric) Seal(ciphertext, nonce, plaintext, additionalData []b
 	copy(ciphertext[len(plaintext):], tag[:])
 }
 
-func (c *aesGcmSivGeneric) Open(plaintext, nonce, ciphertext, additionalData []byte) error {
+func (c *aesGcmSivGeneric) open(plaintext, nonce, ciphertext, additionalData []byte) error {
 	tag := ciphertext[len(ciphertext)-16:]
 	ciphertext = ciphertext[:len(ciphertext)-16]
 

--- a/aes_gcm_noasm.go
+++ b/aes_gcm_noasm.go
@@ -6,4 +6,4 @@
 
 package siv
 
-func newGCM(key []byte) authEnc { return newGCMGeneric(key) }
+func newGCM(key []byte) aead { return newGCMGeneric(key) }

--- a/aes_macros_amd64.s
+++ b/aes_macros_amd64.s
@@ -1,0 +1,288 @@
+// Copyright (c) 2018 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// +build amd64,!gccgo,!appengine
+
+#define AES_ROUND(OPCODE, t, k, keys, r) \
+	MOVUPS (r * 16)(keys), k; \
+	OPCODE k, t
+
+#define AES_ROUND_4(OPCODE, t0, t1, t2, t3, k, keys, r) \
+	MOVUPS (r * 16)(keys), k; \
+	OPCODE k, t0;             \
+	OPCODE k, t1;             \
+	OPCODE k, t2;             \
+	OPCODE k, t3
+
+#define AES_ROUND_8(OPCODE, t0, t1, t2, t3, t4, t5, t6, t7, k, keys, r) \
+	MOVUPS (r * 16)(keys), k; \
+	OPCODE k, t0;             \
+	OPCODE k, t1;             \
+	OPCODE k, t2;             \
+	OPCODE k, t3;             \
+	OPCODE k, t4;             \
+	OPCODE k, t5;             \
+	OPCODE k, t6;             \
+	OPCODE k, t7
+
+#define AES_128(t, k, keys) \
+	AES_ROUND(PXOR, t, k, keys, 0);       \
+	AES_ROUND(AESENC, t, k, keys, 1);     \
+	AES_ROUND(AESENC, t, k, keys, 2);     \
+	AES_ROUND(AESENC, t, k, keys, 3);     \
+	AES_ROUND(AESENC, t, k, keys, 4);     \
+	AES_ROUND(AESENC, t, k, keys, 5);     \
+	AES_ROUND(AESENC, t, k, keys, 6);     \
+	AES_ROUND(AESENC, t, k, keys, 7);     \
+	AES_ROUND(AESENC, t, k, keys, 8);     \
+	AES_ROUND(AESENC, t, k, keys, 9);     \
+	AES_ROUND(AESENCLAST, t, k, keys, 10)
+
+#define AES_192(t, k, keys) \
+	AES_ROUND(PXOR, t, k, keys, 0);       \
+	AES_ROUND(AESENC, t, k, keys, 1);     \
+	AES_ROUND(AESENC, t, k, keys, 2);     \
+	AES_ROUND(AESENC, t, k, keys, 3);     \
+	AES_ROUND(AESENC, t, k, keys, 4);     \
+	AES_ROUND(AESENC, t, k, keys, 5);     \
+	AES_ROUND(AESENC, t, k, keys, 6);     \
+	AES_ROUND(AESENC, t, k, keys, 7);     \
+	AES_ROUND(AESENC, t, k, keys, 8);     \
+	AES_ROUND(AESENC, t, k, keys, 9);     \
+	AES_ROUND(AESENC, t, k, keys, 10);    \
+	AES_ROUND(AESENC, t, k, keys, 11);    \
+	AES_ROUND(AESENCLAST, t, k, keys, 12)
+
+#define AES_256(t, k, keys) \
+	AES_ROUND(PXOR, t, k, keys, 0);       \
+	AES_ROUND(AESENC, t, k, keys, 1);     \
+	AES_ROUND(AESENC, t, k, keys, 2);     \
+	AES_ROUND(AESENC, t, k, keys, 3);     \
+	AES_ROUND(AESENC, t, k, keys, 4);     \
+	AES_ROUND(AESENC, t, k, keys, 5);     \
+	AES_ROUND(AESENC, t, k, keys, 6);     \
+	AES_ROUND(AESENC, t, k, keys, 7);     \
+	AES_ROUND(AESENC, t, k, keys, 8);     \
+	AES_ROUND(AESENC, t, k, keys, 9);     \
+	AES_ROUND(AESENC, t, k, keys, 10);    \
+	AES_ROUND(AESENC, t, k, keys, 11);    \
+	AES_ROUND(AESENC, t, k, keys, 12);    \
+	AES_ROUND(AESENC, t, k, keys, 13);    \
+	AES_ROUND(AESENCLAST, t, k, keys, 14)
+
+#define AES_128_4(c0, c1, c2, c3, k, keys) \
+	AES_ROUND_4(PXOR, c0, c1, c2, c3, k, keys, 0);       \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 1);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 2);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 3);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 4);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 5);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 6);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 7);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 8);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 9);     \
+	AES_ROUND_4(AESENCLAST, c0, c1, c2, c3, k, keys, 10)
+
+#define AES_192_4(c0, c1, c2, c3, k, keys) \
+	AES_ROUND_4(PXOR, c0, c1, c2, c3, k, keys, 0);       \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 1);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 2);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 3);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 4);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 5);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 6);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 7);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 8);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 9);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 10);    \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 11);    \
+	AES_ROUND_4(AESENCLAST, c0, c1, c2, c3, k, keys, 12)
+
+#define AES_256_4(c0, c1, c2, c3, k, keys) \
+	AES_ROUND_4(PXOR, c0, c1, c2, c3, k, keys, 0);       \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 1);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 2);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 3);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 4);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 5);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 6);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 7);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 8);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 9);     \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 10);    \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 11);    \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 12);    \
+	AES_ROUND_4(AESENC, c0, c1, c2, c3, k, keys, 13);    \
+	AES_ROUND_4(AESENCLAST, c0, c1, c2, c3, k, keys, 14)
+
+#define AES_128_8(c0, c1, c2, c3, c4, c5, c6, c7, k, keys) \
+	AES_ROUND_8(PXOR, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 0);       \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 1);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 2);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 3);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 4);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 5);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 6);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 7);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 8);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 9);     \
+	AES_ROUND_8(AESENCLAST, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 10)
+
+#define AES_192_8(c0, c1, c2, c3, c4, c5, c6, c7, k, keys) \
+	AES_ROUND_8(PXOR, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 0);       \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 1);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 2);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 3);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 4);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 5);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 6);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 7);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 8);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 9);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 10);    \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 11);    \
+	AES_ROUND_8(AESENCLAST, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 12)
+
+#define AES_256_8(c0, c1, c2, c3, c4, c5, c6, c7, k, keys) \
+	AES_ROUND_8(PXOR, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 0);       \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 1);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 2);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 3);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 4);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 5);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 6);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 7);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 8);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 9);     \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 10);    \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 11);    \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 12);    \
+	AES_ROUND_8(AESENC, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 13);    \
+	AES_ROUND_8(AESENCLAST, c0, c1, c2, c3, c4, c5, c6, c7, k, keys, 14)
+
+#define EXPAND_KEY_128(keys, n, k1, k2, t) \
+	PSHUFD $0xff, k2, k2;     \
+	SHUFPS $0x10, k1, t;      \
+	PXOR   t, k1;             \
+	SHUFPS $0x8c, k1, t;      \
+	PXOR   t, k1;             \
+	PXOR   k2, k1;            \
+	MOVUPS k1, (n * 16)(keys)
+
+#define EXPAND_KEY_192_A(keys, n, k1, k2, k3, t0, t1, t2, t3) \
+	PSHUFD $0x55, k2, k2;           \
+	SHUFPS $0x10, k1, t0;           \
+	PXOR   t0, k1;                  \
+	SHUFPS $0x8c, k1, t0;           \
+	PXOR   t0, k1;                  \
+	PXOR   k2, k1;                  \
+	MOVAPS k3, t1;                  \
+	MOVAPS k3, t2;                  \
+	PSLLDQ $0x4, t1;                \
+	PSHUFD $0xff, k1, t3;           \
+	PXOR   t3, k3;                  \
+	PXOR   t1, k3;                  \
+	MOVAPS k1, k2;                  \
+	SHUFPS $0x44, k1, t2;           \
+	SHUFPS $0x4e, k3, k2;           \
+	MOVUPS t2, (n * 16)(keys);      \
+	MOVUPS k2, ((n + 1) * 16)(keys)
+
+#define EXPAND_KEY_192_B(keys, n, k1, k2, k3, t0, t1, t2) \
+	PSHUFD $0x55, k2, k2;     \
+	SHUFPS $0x10, k1, t0;     \
+	PXOR   t0, k1;            \
+	SHUFPS $0x8c, k1, t0;     \
+	PXOR   t0, k1;            \
+	PXOR   k2, k1;            \
+	MOVAPS k3, t1;            \
+	PSLLDQ $0x4, t1;          \
+	PSHUFD $0xff, k1, t2;     \
+	PXOR   t2, k3;            \
+	PXOR   t1, k3;            \
+	MOVUPS k1, (n * 16)(keys)
+
+#define EXPAND_KEY_256(keys, n, k1, k2, t) \
+	PSHUFD $0xaa, k2, k2;     \
+	SHUFPS $0x10, k1, t;      \
+	PXOR   t, k1;             \
+	SHUFPS $0x8c, k1, t;      \
+	PXOR   t, k1;             \
+	PXOR   k2, k1;            \
+	MOVUPS k1, (n * 16)(keys)
+
+#define AES_KEY_SCHEDULE_128(keys, k, t0, t1) \
+	PXOR            t1, t1;             \
+	MOVUPS          k, (0 * 16)(keys);  \
+	AESKEYGENASSIST $0x01, k, t0;       \
+	EXPAND_KEY_128(keys, 1, k, t0, t1); \
+	AESKEYGENASSIST $0x02, k, t0;       \
+	EXPAND_KEY_128(keys, 2, k, t0, t1); \
+	AESKEYGENASSIST $0x04, k, t0;       \
+	EXPAND_KEY_128(keys, 3, k, t0, t1); \
+	AESKEYGENASSIST $0x08, k, t0;       \
+	EXPAND_KEY_128(keys, 4, k, t0, t1); \
+	AESKEYGENASSIST $0x10, k, t0;       \
+	EXPAND_KEY_128(keys, 5, k, t0, t1); \
+	AESKEYGENASSIST $0x20, k, t0;       \
+	EXPAND_KEY_128(keys, 6, k, t0, t1); \
+	AESKEYGENASSIST $0x40, k, t0;       \
+	EXPAND_KEY_128(keys, 7, k, t0, t1); \
+	AESKEYGENASSIST $0x80, k, t0;       \
+	EXPAND_KEY_128(keys, 8, k, t0, t1); \
+	AESKEYGENASSIST $0x1b, k, t0;       \
+	EXPAND_KEY_128(keys, 9, k, t0, t1); \
+	AESKEYGENASSIST $0x36, k, t0;       \
+	EXPAND_KEY_128(keys, 10, k, t0, t1)
+
+#define AES_KEY_SCHEDULE_192(keys, k0, k1, t0, t1, t2, t3, t4) \
+	PXOR            t1, t1;                                 \
+	MOVUPS          k0, (0 * 16)(keys);                     \
+	AESKEYGENASSIST $0x01, k1, t0;                          \
+	EXPAND_KEY_192_A(keys, 1, k0, t0, k1, t1, t2, t3, t4);  \
+	AESKEYGENASSIST $0x02, k1, t0;                          \
+	EXPAND_KEY_192_B(keys, 3, k0, t0, k1, t1, t2, t4);      \
+	AESKEYGENASSIST $0x04, k1, t0;                          \
+	EXPAND_KEY_192_A(keys, 4, k0, t0, k1, t1, t2, t3, t4);  \
+	AESKEYGENASSIST $0x08, k1, t0;                          \
+	EXPAND_KEY_192_B(keys, 6, k0, t0, k1, t1, t2, t4);      \
+	AESKEYGENASSIST $0x10, k1, t0;                          \
+	EXPAND_KEY_192_A(keys, 7, k0, t0, k1, t1, t2, t3, t4);  \
+	AESKEYGENASSIST $0x20, k1, t0;                          \
+	EXPAND_KEY_192_B(keys, 9, k0, t0, k1, t1, t2, t4);      \
+	AESKEYGENASSIST $0x40, k1, t0;                          \
+	EXPAND_KEY_192_A(keys, 10, k0, t0, k1, t1, t2, t3, t4); \
+	AESKEYGENASSIST $0x80, k1, t0;                          \
+	EXPAND_KEY_192_B(keys, 12, k0, t0, k1, t1, t2, t4)
+
+#define AES_KEY_SCHEDULE_256(keys, k0, k1, t0, t1) \
+	PXOR            t1, t1;               \
+	MOVUPS          k0, (0 * 16)(keys);   \
+	MOVUPS          k1, (1 * 16)(keys);   \
+	AESKEYGENASSIST $0x01, k1, t0;        \
+	EXPAND_KEY_128(keys, 2, k0, t0, t1);  \
+	AESKEYGENASSIST $0x01, k0, t0;        \
+	EXPAND_KEY_256(keys, 3, k1, t0, t1);  \
+	AESKEYGENASSIST $0x02, k1, t0;        \
+	EXPAND_KEY_128(keys, 4, k0, t0, t1);  \
+	AESKEYGENASSIST $0x02, k0, t0;        \
+	EXPAND_KEY_256(keys, 5, k1, t0, t1);  \
+	AESKEYGENASSIST $0x04, k1, t0;        \
+	EXPAND_KEY_128(keys, 6, k0, t0, t1);  \
+	AESKEYGENASSIST $0x04, k0, t0;        \
+	EXPAND_KEY_256(keys, 7, k1, t0, t1);  \
+	AESKEYGENASSIST $0x08, k1, t0;        \
+	EXPAND_KEY_128(keys, 8, k0, t0, t1);  \
+	AESKEYGENASSIST $0x08, k0, t0;        \
+	EXPAND_KEY_256(keys, 9, k1, t0, t1);  \
+	AESKEYGENASSIST $0x10, k1, t0;        \
+	EXPAND_KEY_128(keys, 10, k0, t0, t1); \
+	AESKEYGENASSIST $0x10, k0, t0;        \
+	EXPAND_KEY_256(keys, 11, k1, t0, t1); \
+	AESKEYGENASSIST $0x20, k1, t0;        \
+	EXPAND_KEY_128(keys, 12, k0, t0, t1); \
+	AESKEYGENASSIST $0x20, k0, t0;        \
+	EXPAND_KEY_256(keys, 13, k1, t0, t1); \
+	AESKEYGENASSIST $0x40, k1, t0;        \
+	EXPAND_KEY_128(keys, 14, k0, t0, t1)

--- a/siv.go
+++ b/siv.go
@@ -54,10 +54,10 @@ import (
 
 var errOpen = errors.New("siv: message authentication failed")
 
-type authEnc interface {
-	Seal(ciphertext, nonce, plaintext, additionalData []byte)
+type aead interface {
+	seal(ciphertext, nonce, plaintext, additionalData []byte)
 
-	Open(plaintext, nonce, ciphertext, additionalData []byte) error
+	open(plaintext, nonce, ciphertext, additionalData []byte) error
 }
 
 // sliceForAppend takes a slice and a requested number of bytes. It returns a


### PR DESCRIPTION
This commit adds an AMD64 assemeber implementation for
AES-SIV-CMAC. This includes generic AMD64 AES macros and
an AES-CTR assembler implementation.

Further it adds CI assembler formating checks and asm tests.
The asm AES-CTR implementation improves performance about
30%-70% depending on the message size.

```
name                old time/op    new time/op     delta
AES128CMACSeal64-4    1.29µs ± 1%     0.36µs ± 2%  -71.73%  (p=0.000 n=4+3)
AES128CMACSeal1K-4    3.49µs ± 0%     2.03µs ± 1%  -41.82%  (p=0.000 n=4+3)
AES128CMACSeal8K-4    23.8µs ± 0%     14.4µs ± 0%  -39.63%  (p=0.000 n=4+3)
AES128CMACOpen64-4    1.29µs ± 0%     0.36µs ± 0%  -72.05%  (p=0.000 n=4+3)
AES128CMACOpen1K-4    3.52µs ± 0%     2.04µs ± 1%  -42.09%  (p=0.000 n=4+3)
AES128CMACOpen8K-4    23.8µs ± 0%     14.4µs ± 0%  -39.59%  (p=0.000 n=4+3)
AES192CMACSeal64-4    1.38µs ± 0%     0.37µs ± 0%  -73.21%  (p=0.000 n=4+3)
AES192CMACSeal1K-4    3.81µs ± 0%     2.22µs ± 1%  -41.70%  (p=0.000 n=4+3)
AES192CMACSeal8K-4    26.5µs ± 0%     16.9µs ±11%  -36.33%  (p=0.000 n=4+3)
AES192CMACOpen64-4    1.39µs ± 1%     0.47µs ± 2%  -66.47%  (p=0.000 n=4+3)
AES192CMACOpen1K-4    3.87µs ± 1%     2.88µs ± 0%  -25.60%  (p=0.000 n=4+3)
AES192CMACOpen8K-4    27.2µs ± 2%     19.7µs ± 1%  -27.69%  (p=0.000 n=4+3)
AES256CMACSeal64-4    1.61µs ± 9%     0.48µs ± 0%  -70.10%  (p=0.000 n=4+3)
AES256CMACSeal1K-4    4.71µs ± 9%     3.04µs ± 0%  -35.51%  (p=0.000 n=4+3)
AES256CMACSeal8K-4    35.5µs ± 0%     21.2µs ± 0%  -40.11%  (p=0.000 n=4+3)
AES256CMACOpen64-4    1.77µs ± 0%     0.49µs ± 1%  -72.12%  (p=0.000 n=4+3)
AES256CMACOpen1K-4    5.15µs ± 1%     3.04µs ± 0%  -40.93%  (p=0.000 n=4+3)
AES256CMACOpen8K-4    35.4µs ± 0%     21.3µs ± 0%  -39.87%  (p=0.000 n=4+3)
```